### PR TITLE
Configure through environment

### DIFF
--- a/app/models/hesburgh_api/search_base.rb
+++ b/app/models/hesburgh_api/search_base.rb
@@ -35,8 +35,12 @@ module HesburghAPI
       end
 
       def self.yml
-        @yml ||= YAML.load_file(File.join(Rails.root, "config", 'hesburgh_api.yml'))
-        @yml[Rails.env]
+        path = File.join(Rails.root, "config", "hesburgh_api.yml")
+        template = ERB.new(File.read(path))
+        processed = template.result(binding)
+
+        @yml ||= YAML.load(processed)
+        @yml.fetch(Rails.env)
       end
 
   end


### PR DESCRIPTION
Changes the search API to allow configuring the endpoint and token
through env keys. For example, an application can now create a
config/hesburgh_api.yml like:
```
settings_from_env: &settings_from_env
  token: <%= ENV['HAPI_TOKEN'] %>
  url: <%= ENV['HAPI_URL'] %>
pre_production:
  <<: *settings_from_env
production:
  <<: *settings_from_env
```